### PR TITLE
Removed loading from explore when have no more collections to search

### DIFF
--- a/src/views/Collections/Collections.js
+++ b/src/views/Collections/Collections.js
@@ -74,7 +74,7 @@ const Collections = (props) => {
 
         setPublicCollections(collectionsConcat);
         setFilteredPublicCollections(collectionsConcat);
-        setHasMoreCollections(data.rows.length !== 0);
+        setHasMoreCollections(data.rows.length < data.count);
         setOffset(offset + data.rows.length);
       }
     } catch (error) {


### PR DESCRIPTION
- Removed loading from explore when have no more collections to search